### PR TITLE
Add comment for pyup to ignore the update to ipython 6.0.0

### DIFF
--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -11,7 +11,7 @@ factory_boy==2.8.1
 django-debug-toolbar==1.7
 
 # improved REPL
-ipython==5.3.0
+ipython==5.3.0 # pyup: >=5.3.0,<6.0.0
 ipdb==0.10.3
 
 pytest-django==3.1.2


### PR DESCRIPTION
IPython 6.0.0 does not support Python version <3.0 anymore. We need to tell pyup to ignore updates for version >=6.0.0. 