### PR TITLE
Redirect '/preview' to '/'

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -16,6 +16,10 @@ urlpatterns = [
     # url(r'^preview$', TemplateView.as_view(template_name='pages/preview.html'), name="preview"),
     # url(r'^about/$', TemplateView.as_view(template_name='pages/about.html'), name="about"),
 
+    # Do a redirect for people might have the .../preview saved in browser.
+
+    url(r'^preview/', RedirectView.as_view(pattern_name='home')),
+
     # Django Admin, use {% url 'admin:index' %}
     url(settings.ADMIN_URL, include(admin.site.urls)),
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,11 +13,8 @@ from geomat.stein.views import GalleryListView, gallery_view
 
 urlpatterns = [
     url(r'^$', gallery_view, name="home"),
-    # url(r'^preview$', TemplateView.as_view(template_name='pages/preview.html'), name="preview"),
-    # url(r'^about/$', TemplateView.as_view(template_name='pages/about.html'), name="about"),
 
-    # Do a redirect for people might have the .../preview saved in browser.
-
+    # Redirect users from outdated 'preview/' to '/'
     url(r'^preview/', RedirectView.as_view(pattern_name='home')),
 
     # Django Admin, use {% url 'admin:index' %}
@@ -27,10 +24,9 @@ urlpatterns = [
     url(r'^users/', include("geomat.users.urls", namespace="users")),
     url(r'^accounts/', include('allauth.urls')),
 
-    # Your stuff: custom urls includes go here
-
-    # Let's fix this stupid issue with Google Chrome and make a redirect from /favicon.ico to our /img/favicon.ico file!
-    # Google Chrome ignores the favicon file defined in HTML and always looks for it in /
+    # Let's fix this stupid issue with Google Chrome and make a redirect from '/favicon.ico' to our 
+    # 'common/images/favicon.ico' file!
+    # Google Chrome ignores the favicon file defined in HTML and always looks for it in '/favicon.ico'
     url(
         r'^favicon.ico$',
         RedirectView.as_view(


### PR DESCRIPTION
Das Projekt wurde ehemals mit dem Suffix `preview/` beworben, welcher aber mittlerweile im Code entfernt wurde. Der Commit führt einen Redirect von `preview/` auf `/` ein.