### PR TITLE
Change default DATABASE_URL settings

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -111,7 +111,7 @@ MANAGERS = ADMINS
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {
     # Raises ImproperlyConfigured exception if DATABASE_URL not in os.environ
-    'default': env.db("DATABASE_URL", default="postgres:///django-geomat"),
+    'default': env.db("DATABASE_URL", default="postgres://postgres@localhost:5432/postgres"),
 }
 DATABASES['default']['ATOMIC_REQUESTS'] = True
 

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -28,7 +28,7 @@ SECRET_KEY = env("DJANGO_SECRET_KEY", default='3(!oafihrr4deyrh5=vs_sr*8@f-vo=ty
 
 # ALLOWED HOSTS
 # ------------------------------------------------------------------------------
-ALLOWED_HOSTS = ['192.168.99.100', ]
+ALLOWED_HOSTS = ['192.168.99.100', 'localhost']
 
 # Mail settings
 # ------------------------------------------------------------------------------

--- a/dev.yml
+++ b/dev.yml
@@ -13,6 +13,8 @@ services:
       - postgres_backup_dev:/backups
     environment:
       - POSTGRES_USER=django-geomat
+    ports:
+      - "5432:5432"
 
   django:
     build:


### PR DESCRIPTION
Now it's possible to start Postgres in a Docker container via

```
docker run --name geomat-postgres -e POSTGRES_USER=postgres -d -p 5432:5432 postgres
```
and afterwards start a local Django server with `python manage.py runserver_plus`, which will use the dockerized Postgres instance.

By forwarding the port `5432` inside `dev.yml`, we can actually use `docker-compose -f dev.yml up postgres` to start a new postgres instance.