### PR TITLE
Update Travis-CI build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,8 @@
-sudo: true
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq build-essential gettext python-dev zlib1g-dev libpq-dev xvfb
-  - sudo apt-get install -qq libtiff4-dev libjpeg8-dev libfreetype6-dev liblcms1-dev libwebp-dev
-  - sudo apt-get install -qq graphviz-dev python-setuptools python3-dev python-virtualenv python-pip
-  - sudo apt-get install -qq firefox automake libtool libreadline6 libreadline6-dev libreadline-dev
-  - sudo apt-get install -qq libsqlite3-dev libxml2 libxml2-dev libssl-dev libbz2-dev wget curl llvm
+sudo: false
 language: python
 python:
   - "2.7"
 install:
-  - "pip install -U setuptools"
   - "pip install -r requirements/local.txt"
 script:
   - "py.test --cov=./"


### PR DESCRIPTION
- Change `sudo: true` to `sudo:false`.
- Remove the apt installation, because we do not need it.
- Remove explicit setuptools update. Don't think we need that anymore.