### PR TITLE
Add maximal memory size for uploads

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -203,6 +203,9 @@ MEDIA_ROOT = str(APPS_DIR('media'))
 # See: https://docs.djangoproject.com/en/dev/ref/settings/#media-url
 MEDIA_URL = '/media/'
 
+# See: https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-FILE_UPLOAD_MAX_MEMORY_SIZE
+FILE_UPLOAD_MAX_MEMORY_SIZE = 200000000
+
 # URL Configuration
 # ------------------------------------------------------------------------------
 ROOT_URLCONF = 'config.urls'


### PR DESCRIPTION
Uploading images larger than 2.5 MB currently does not work.

Setting `FILE_UPLOAD_MAX_MEMORY_SIZE` to a higher value (we're going to use `200 MB` here), resolves this issue. A limit was introduced in Django 1.10, as described [here](https://docs.djangoproject.com/en/1.11/ref/settings/#data-upload-max-memory-size).