### PR TITLE
Fully upgrade to python 3

### DIFF
--- a/compose/django/Dockerfile
+++ b/compose/django/Dockerfile
@@ -1,5 +1,4 @@
-
-FROM python:2.7
+FROM python:3.6
 ENV PYTHONUNBUFFERED 1
 
 # Requirements have to be pulled and installed here, otherwise caching won't work

--- a/compose/django/Dockerfile-dev
+++ b/compose/django/Dockerfile-dev
@@ -1,5 +1,4 @@
-
-FROM python:2.7
+FROM python:3.6
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update && apt-get install -y gettext


### PR DESCRIPTION
In our recent Python 3 PR we forgot to actually update the Dockerfiles to use Python 3 instead of Python 2. This PR solves that.