### PR TITLE
Add MathJax to Django Admin

### DIFF
--- a/geomat/static/common/css/mathjax.css
+++ b/geomat/static/common/css/mathjax.css
@@ -1,0 +1,12 @@
+#editor-output-label {
+  font-weight: bold;
+}
+
+#editor-output {
+  margin-left: 170px;
+  padding: 10px;
+}
+
+#editor > input {
+  width: 40%;
+}

--- a/geomat/static/common/js/mathjax-vue.js
+++ b/geomat/static/common/js/mathjax-vue.js
@@ -1,0 +1,21 @@
+window.onload = function () {
+  let field = document.getElementById('id_chemical_formula')
+  new Vue({
+    el: '#editor',
+    data: {
+      input: '',
+      output: ''
+    },
+    created: function () {
+      this.input = field.value
+    },
+    watch: {
+      input: _.debounce(function(e) {
+        this.output = '\\(' + this.input + '\\)'
+        this.$nextTick(function() {
+          MathJax.Hub.Queue(["Typeset", MathJax.Hub, "editor-output"])
+        })
+      }, 300)
+    }
+  })
+}

--- a/geomat/stein/admin.py
+++ b/geomat/stein/admin.py
@@ -1,12 +1,19 @@
-
-
 from django.contrib import admin
 from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
-from geomat.stein.forms import GlossaryEntryModelForm
 
-from geomat.stein.models import (Classification, CrystalSystem, Handpiece, MineralType, Photograph, GlossaryEntry,
-                                 QuizQuestion, QuizAnswer, Cleavage)
+from geomat.stein.forms import GlossaryEntryModelForm, MineralTypeAdminForm
+from geomat.stein.models import (
+    Classification,
+    Cleavage,
+    CrystalSystem,
+    GlossaryEntry,
+    Handpiece,
+    MineralType,
+    Photograph,
+    QuizAnswer,
+    QuizQuestion
+)
 
 
 class CleavageInline(admin.TabularInline):
@@ -65,14 +72,12 @@ admin.site.register(CrystalSystem, CrystallSystemAdmin)
 
 
 class MineralTypeAdmin(admin.ModelAdmin):
+    form = MineralTypeAdminForm
     list_display = ('trivial_name', 'classification', 'systematics', 'variety',
                     'minerals', 'mohs_scale', 'created_at', 'last_modified',
                     'id')
 
-    inlines = [
-        CrystalSystemInline,
-        CleavageInline
-    ]
+    inlines = [CrystalSystemInline, CleavageInline]
 
 
 admin.site.register(MineralType, MineralTypeAdmin)
@@ -129,9 +134,7 @@ admin.site.register(QuizAnswer, QuizAnswerAdmin)
 
 class QuizQuestionAdmin(admin.ModelAdmin):
     list_display = ('id', 'tags', 'difficulty', 'qtype')
-    inlines = [
-        QuizAnswerInline
-    ]
+    inlines = [QuizAnswerInline]
 
 
 admin.site.register(QuizQuestion, QuizQuestionAdmin)

--- a/geomat/stein/forms.py
+++ b/geomat/stein/forms.py
@@ -1,5 +1,8 @@
-from django.forms import ModelForm, Textarea, CharField
+from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
+from django.forms import CharField, ModelForm, Textarea
+from django.forms.widgets import TextInput
+
 from geomat.stein.models import GlossaryEntry
 
 # This Form was used to enabel full sentences with commas in a ArrayField by defining a | separator
@@ -7,13 +10,32 @@ from geomat.stein.models import GlossaryEntry
 
 
 class GlossaryEntryModelForm(ModelForm):
-    examples = SimpleArrayField(base_field=CharField(),
-                                delimiter='|',
-                                widget=Textarea,
-                                help_text=
-                                "When giving more than one example seperate them with a '|' ( Alt Gr + >-Button)."
-                                )
+    examples = SimpleArrayField(
+        base_field=CharField(),
+        delimiter='|',
+        widget=Textarea,
+        help_text=
+        "When giving more than one example seperate them with a '|' ( Alt Gr + >-Button)."
+    )
 
     class Meta:
         model = GlossaryEntry
         fields = '__all__'
+
+
+class MineralTypeAdminForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(MineralTypeAdminForm, self).__init__(*args, **kwargs)
+        self.fields['chemical_formula'].widget = MathJaxField()
+
+
+class MathJaxField(TextInput):
+    class Media:
+        js = (
+            'https://unpkg.com/lodash@4.16.0/lodash.min.js',
+            'https://unpkg.com/vue@latest/dist/vue.min.js',
+            'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML',
+            'common/js/mathjax-vue.js')
+        css = {'all': ('common/css/mathjax.css', )}
+
+    template_name = 'widgets/mathjax.html'

--- a/geomat/stein/templates/widgets/mathjax.html
+++ b/geomat/stein/templates/widgets/mathjax.html
@@ -1,0 +1,5 @@
+<div id="editor">
+  <input v-model="input" type="{{ widget.type }}" name="{{ widget.name }}"{% if widget.value != None %} value="{{ widget.value|stringformat:'s' }}"{% endif %}{% include "django/forms/widgets/attrs.html" %} />
+  <div id="editor-output-label">Live preview:</div>
+  <div v-html="output" id="editor-output"></div>
+</div>


### PR DESCRIPTION
We now have a live preview for the `chemical_formula` field in the Django admin using MathJax and VueJS.

# Changelog

* The `chemical_formula` field now has a live preview, when editing MineralType
  objects. We're using VueJS here.
* The initial code was found on JSFiddle (http://jsfiddle.net/akiyah/vevygfzb/)
  and was originally written by user `akiyah`.
* We use very lazily written CSS.
* Fixes #12.