### PR TITLE
FIx Travis Buildprocess

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ sudo: false
 services:
   - postgresql
 
+addons:
+  postgresql: "9.4"
+
 language: python
 python:
   - "3.6"


### PR DESCRIPTION
The Travis buildprocess uses PostgrSQL 9.2 however Dajngo only supports 9.4* this is fixed here.
