### PR TITLE
Docs fix

### DIFF
--- a/geomat/stein/serializers.py
+++ b/geomat/stein/serializers.py
@@ -4,6 +4,8 @@ from rest_framework import serializers
 from geomat.stein.models import CrystalSystem, Handpiece, MineralType, Photograph, QuizQuestion,\
     QuizAnswer, Cleavage, GlossaryEntry
 
+from drf_yasg.utils import swagger_serializer_method
+
 
 class StdImageField(serializers.ImageField):
     """
@@ -51,6 +53,7 @@ class StdImageField(serializers.ImageField):
 
 
 class CleavageSerializer(serializers.ModelSerializer):
+
     cleavage = serializers.SerializerMethodField()
 
     class Meta:
@@ -107,28 +110,22 @@ class MineralTypeSerializer(serializers.ModelSerializer):
     def get_split_systematics(self, obj):
         return obj.get_split_systematics_display()
 
+    @swagger_serializer_method(serializer_or_field=serializers.ListField)
     def get_fracture(self, obj):
         lst = []
         choice_dict = dict(obj.FRACTURE_CHOICES)
-        if obj.lustre:
-            for choice in obj.fracture:
-                lst.append(choice_dict.get(choice))
+        fracture = obj.fracture
+        if fracture:
+            lst = [choice_dict.get(choice) for choice in fracture]
         return lst
 
-    def get_cleavage(self, obj):
-        lst = []
-        choice_dict = dict(obj.CLEAVAGE_CHOICES)
-        if obj.cleavage:
-            for choice in obj.cleavage:
-                lst.append(choice_dict.get(choice))
-        return lst
-
+    @swagger_serializer_method(serializer_or_field=serializers.ListField)
     def get_lustre(self, obj):
         lst = []
         choice_dict = dict(obj.LUSTRE_CHOICES)
-        if obj.lustre:
-            for choice in obj.lustre:
-                lst.append(choice_dict.get(choice))
+        lustre = obj.lustre
+        if lustre:
+            lst = [choice_dict.get(choice) for choice in lustre]
         return lst
 
     def get_density(self,obj):

--- a/geomat/stein/serializers.py
+++ b/geomat/stein/serializers.py
@@ -162,7 +162,7 @@ class MineralProfilesSerializer(MineralTypeSerializer):
             photo_pk = MineralProfilesSerializer.IMAGE_DICT[obj.pk]
             photo = Photograph.objects.only("image_file").get(pk=photo_pk)
             return StdImageField().to_representation(obj=photo.image_file)
-        return {}
+        return None
 
 
 class CrystalSystemFullSerializer(serializers.ModelSerializer):

--- a/geomat/stein/serializers.py
+++ b/geomat/stein/serializers.py
@@ -95,6 +95,7 @@ class MineralTypeSerializer(serializers.ModelSerializer):
     density =serializers.SerializerMethodField()
     mohs_scale = serializers.SerializerMethodField()
     crystal_system = CrystalSystemLessSerializer(many=True)
+    cleavage = CleavageSerializer(many=True)
 
     class Meta:
         model = MineralType


### PR DESCRIPTION
We fix the Docs with :

- [x] Correct display of `fracture`in `MineralTypeSerializer` to be `[string]`
- [x] Correct display of `lustre` in `MineralTypeSerializer` to be `[string]`
- [x] `image_files` should have `null` as response value if no images are present

We fix the `MineralTypeSerializer` with :

- [x] adding `cleavage` Field with `CleavageSerializer`